### PR TITLE
nodejs version compatible with gitbook-cli

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: '12.18.2'
       - run: sudo apt update
       - run: sudo apt install calibre-bin
       - run: sudo npm install -g gitbook-cli


### PR DESCRIPTION
Explicitly specify latest version of nodejs which is compatible with abandoned 'gitbook-cli' v2.3.2